### PR TITLE
Fix typo in README

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -2,7 +2,7 @@
 
 ## What is it? #################################################################
 
-DFBnc is an open-source, MIT-Licensed, multi-tennant, java-based IRC Bouncer.
+DFBnc is an open-source, MIT-Licensed, multi-tenant, java-based IRC Bouncer.
 
 ## CI ##########################################################################
 


### PR DESCRIPTION
For reference, this is a Tennant:

![david-tennant_hi_09012015](https://cloud.githubusercontent.com/assets/189133/12594672/2088592e-c46f-11e5-897e-dacfe90738d9.gif)

I couldn't find any evidence of multiple Tennants in DFBnc, so I assume it must be a typo.