### PR TITLE
Add setting to disable auto-bursting of channels. (#95)

### DIFF
--- a/src/com/dfbnc/ConnectionHandler.java
+++ b/src/com/dfbnc/ConnectionHandler.java
@@ -115,7 +115,7 @@ public interface ConnectionHandler {
      * @param channel Channel Name
      * @return True if this socket is allowed, else false.
      */
-    boolean allowedChannel(final UserSocket user, final String channel);
+    boolean activeAllowedChannel(final UserSocket user, final String channel);
 
     /**
      * Subscribe to any ConnectionHandler Event Buses.

--- a/src/com/dfbnc/commands/AbstractSetCommand.java
+++ b/src/com/dfbnc/commands/AbstractSetCommand.java
@@ -71,7 +71,7 @@ public abstract class AbstractSetCommand extends Command {
         if (wantedClientID == null) {
             output.addBotMessage("[Editing Global Client Settings]");
         } else {
-            output.addBotMessage("[Editing Sub-Client Settings for: %s]", actualParams[2]);
+            output.addBotMessage("[Editing Sub-Client Settings for: %s]", wantedClientID);
         }
         output.addBotMessage("");
 

--- a/src/com/dfbnc/commands/user/UserSetCommand.java
+++ b/src/com/dfbnc/commands/user/UserSetCommand.java
@@ -52,6 +52,7 @@ public class UserSetCommand extends AbstractSetCommand {
         // Add the valid params
         validParams.put("readonly", new ParamInfo("Prevent a sub-client being able to change any settings. (If you set this on yourself, you will be unable to unset it.)", ParamType.BOOL, false));
         validParams.put("activeclient", new ParamInfo("Is this client counted for the purposes of performing offline actions? (eg offlinenick, dperform, aperform)", ParamType.BOOL, false));
+        validParams.put("autoburst", new ParamInfo("Should this client be automatically joined into channels on connect? (If FALSE then PARTs from this client just remove that client from the channel not the whole bouncer)", ParamType.BOOL, true));
     }
 
     /**

--- a/src/com/dfbnc/defaults.config
+++ b/src/com/dfbnc/defaults.config
@@ -15,6 +15,7 @@ user:
     suspendReason=
     activeclient=true
     readonly=false
+    autoburst=true
 
 server:
     reconnect=false

--- a/src/com/dfbnc/sockets/UserSocket.java
+++ b/src/com/dfbnc/sockets/UserSocket.java
@@ -570,16 +570,6 @@ public class UserSocket extends ConnectedSocket {
     }
 
     /**
-     * Is this socket allowed to interact with the given channel name?
-     *
-     * @param channel Channel Name
-     * @return True if this socket is allowed, else false.
-     */
-    public boolean allowedChannel(final String channel) {
-        return (myAccount.getConnectionHandler() == null) || myAccount.getConnectionHandler().allowedChannel(this, channel);
-    }
-
-    /**
      * Send a given raw line to all sockets
      *
      * @param line Line to send
@@ -605,7 +595,8 @@ public class UserSocket extends ConnectedSocket {
      */
     public void sendAllChannel(final String channel, final String line, final boolean ignoreThis) {
         for (UserSocket socket : this.getAccount().getUserSockets()) {
-            if (ignoreThis && socket == this || !socket.allowedChannel(channel)) {
+            boolean allowedChannel = (myAccount.getConnectionHandler() == null) || myAccount.getConnectionHandler().activeAllowedChannel(this, channel);
+            if (ignoreThis && socket == this || !allowedChannel) {
                 continue;
             }
 


### PR DESCRIPTION
Closes Issue #95.

By default, user.autoburst is set to true (Which makes a bursty-client)

This can be changed with ` /dfbnc userset --subclient foo autoburst false` or ` /dfbnc userset --global autoburst false` (and then ` /dfbnc userset --subclient foo autoburst true` to make only a certain subclient bursty if desired)

This will disable the automatic channel burst on connect and only join a non-bursty client into channel they explicitly JOIN.

Any attempts at PARTing a channel from a non-bursty client will result in the client appearing to have left the channel (and receiving no further messages from it), but the bouncer and other clients will remain (unless `PART -f #channel` is used)

Behaviour is the same as before for bursty clients (PARTing takes the whole client out of the channel).

If the bouncer PARTs or is KICKed from a channel, all non-bursty clients are de-activated in that channel and must JOIN again to re-participate.