### PR TITLE
Make IRCConnectionHandler do less in its ctor.

### DIFF
--- a/src/com/dfbnc/servers/irc/IRCServerType.java
+++ b/src/com/dfbnc/servers/irc/IRCServerType.java
@@ -180,6 +180,8 @@ public class IRCServerType extends ServerType {
      */
     @Override
     public IRCConnectionHandler newConnectionHandler(final Account acc, final int serverNum) throws UnableToConnectException {
-        return new IRCConnectionHandler(acc, serverNum);
+        IRCConnectionHandler handler = new IRCConnectionHandler(acc, serverNum);
+        handler.init();
+        return handler;
     }
 }


### PR DESCRIPTION
Starting threads and timers is... unideal. Move them into
an init method to increase the slim chance this might be
unit tested in the futre.